### PR TITLE
Default TTL Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+# 0.0.11
+
+* Added in default TTL options to pass to the cache
+
+# 0.0.10
+
+* Added ability to set redis host/port via options
+
 # 0.0.9
 
 * Fix test errors caused by Redis error event-emitter 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ multiCache.get('myKey', function(err, result) {
   `localOptions` to an object to be used when creating the local cache.
   * `remoteOptions` - if a string is passed in for the remoteCache then set
   `remoteOptions` to an object to be used when creating the remote cache.
-
+  * `ttl` - set a default ttl on call cache objects, may be overridden by 
+  setting the ttl during a `set` call.
+  * `disabled` - disable all cache options. This is to facilitate a testing
+  harness, or disabling during CI testing.
+  
 ## `set(key, value[, ttl, options, callback])`
 
 * `key`

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -10,6 +10,9 @@ var MultiCache = (function(){
   function MultiCache(localCache, remoteCache, options) {
     this.options = options != null ? options : {};
     if(!this.options.disabled) {
+      this.options.ttl = this.options.hasOwnProperty('ttl') ?
+        this.options.ttl
+        : undefined;
       this.useLocalCacheDefault = this.options.hasOwnProperty('useLocalCache') ?
         this.options.useLocalCache
         : true;
@@ -84,6 +87,7 @@ var MultiCache = (function(){
       }
     }
 
+
     if(this.options.disabled) {
       if(callback) {
         return callback(null);
@@ -97,6 +101,9 @@ var MultiCache = (function(){
 
   MultiCache.prototype._set = function(key, value, ttl, options, callback) {
     var setters = this._useMethods(options, 'set');
+
+    //if the ttl is still undefined, check the options for it
+    ttl = ttl ? ttl : this.options.ttl;
 
     if(setters.length === 0) {
       var err = new MultiError('local or remote must be specified when setting to cache');

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -10,9 +10,6 @@ var MultiCache = (function(){
   function MultiCache(localCache, remoteCache, options) {
     this.options = options != null ? options : {};
     if(!this.options.disabled) {
-      this.options.ttl = this.options.hasOwnProperty('ttl') ?
-        this.options.ttl
-        : undefined;
       this.useLocalCacheDefault = this.options.hasOwnProperty('useLocalCache') ?
         this.options.useLocalCache
         : true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-level-cache",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Manage local and remote caches with a single API",
   "main": "index.js",
   "public": true,

--- a/test/lib/test.multi.js
+++ b/test/lib/test.multi.js
@@ -664,7 +664,7 @@ tests.forEach(function(test){
     describe('Cache Expiration', function(){
       it('should evict from cache based on TTL', function (done) {
         this.timeout(3000);
-        var multiCache = new MultiCache(localCacheName, remoteCacheName);
+        var multiCache = new MultiCache(localCacheName, remoteCacheName, {'ttl': 15});
         var ttl = 1; // seconds
         multiCache.set(key, 'myValue', ttl, function (err, result) {
           assert(!err);

--- a/test/lib/test.multi.js
+++ b/test/lib/test.multi.js
@@ -735,8 +735,7 @@ tests.forEach(function(test){
       it('should evict from cache based on the default TTL', function (done) {
         this.timeout(3000);
         var multiCache = new MultiCache(localCacheName, remoteCacheName, {'ttl': 1});
-        var ttl; //unset here to force the use of the options object
-        multiCache.set(key, 'myValue', ttl, function (err, result) {
+        multiCache.set(key, 'myValue', function (err, result) {
           assert(!err);
           assert(!_.isEmpty(result));
           // Check that key is in both local and remote cache

--- a/test/lib/test.multi.js
+++ b/test/lib/test.multi.js
@@ -664,8 +664,78 @@ tests.forEach(function(test){
     describe('Cache Expiration', function(){
       it('should evict from cache based on TTL', function (done) {
         this.timeout(3000);
+        var multiCache = new MultiCache(localCacheName, remoteCacheName);
+        var ttl = 1; // seconds
+        multiCache.set(key, 'myValue', ttl, function (err, result) {
+          assert(!err);
+          assert(!_.isEmpty(result));
+          // Check that key is in both local and remote cache
+          multiCache.get(key, testLocalOnly, function (err, value) {
+            assert(!err);
+            assert(!_.isEmpty(value));
+            assert.equal(value, 'myValue');
+            multiCache.get(key, testRemoteOnly, function (err, value) {
+              assert(!err);
+              assert(!_.isEmpty(value));
+              assert.equal(value, 'myValue');
+              // Test that key/value is evicted after 3 seconds
+              setTimeout(function () {
+                multiCache.get(key, testLocalOnly, function (err, value) {
+                  assert(err);
+                  assert(err.keyNotFound);
+                  assert.equal(undefined, value);
+                  multiCache.get(key, testRemoteOnly, function (err, value) {
+                    assert(err);
+                    assert(err.keyNotFound);
+                    assert.equal(undefined, value);
+                    done();
+                  });
+                });
+              }, 2000);
+            });
+          });
+        });
+      });
+
+      it('should evict from cache based on TTL, ignoring default TTL', function (done) {
+        this.timeout(3000);
         var multiCache = new MultiCache(localCacheName, remoteCacheName, {'ttl': 15});
         var ttl = 1; // seconds
+        multiCache.set(key, 'myValue', ttl, function (err, result) {
+          assert(!err);
+          assert(!_.isEmpty(result));
+          // Check that key is in both local and remote cache
+          multiCache.get(key, testLocalOnly, function (err, value) {
+            assert(!err);
+            assert(!_.isEmpty(value));
+            assert.equal(value, 'myValue');
+            multiCache.get(key, testRemoteOnly, function (err, value) {
+              assert(!err);
+              assert(!_.isEmpty(value));
+              assert.equal(value, 'myValue');
+              // Test that key/value is evicted after 3 seconds
+              setTimeout(function () {
+                multiCache.get(key, testLocalOnly, function (err, value) {
+                  assert(err);
+                  assert(err.keyNotFound);
+                  assert.equal(undefined, value);
+                  multiCache.get(key, testRemoteOnly, function (err, value) {
+                    assert(err);
+                    assert(err.keyNotFound);
+                    assert.equal(undefined, value);
+                    done();
+                  });
+                });
+              }, 2000);
+            });
+          });
+        });
+      });
+
+      it('should evict from cache based on the default TTL', function (done) {
+        this.timeout(3000);
+        var multiCache = new MultiCache(localCacheName, remoteCacheName, {'ttl': 1});
+        var ttl; //unset here to force the use of the options object
         multiCache.set(key, 'myValue', ttl, function (err, result) {
           assert(!err);
           assert(!_.isEmpty(result));


### PR DESCRIPTION
This is for setting a default TTL for all cache objects, this way you don't have to set it yourself.  See the updated API documentation at the constructor for more information.
