### PR TITLE
Fix transaction issue. Fixes #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.1
+
+* Fix bug stemming from non-transaction safe setting of data + TTL
+
 # 1.0.0
 
 * Node versions supported changes from 0.10 & 0.12 to 6.0.0, 7.0.0, 7.9.0

--- a/lib/cache-lib/redis.js
+++ b/lib/cache-lib/redis.js
@@ -26,16 +26,13 @@ function getCacheInterface(client, errorState) {
       if(errorState.isError) {
         return callback(getError());
       }
-      client.set(key, JSON.stringify(value), function(err, reply){
-        if(err) {
-          return callback(err, reply);
-        }
-        if(ttl > 0){
-          client.expire(key, ttl, callback);
-        } else {
-          callback(err, reply);
-        }
-      });
+      var stringValue = JSON.stringify(value);
+
+      if(ttl > 0){
+        client.set(key, stringValue, 'EX', ttl, callback);
+      } else {
+        client.set(key, stringValue, callback);
+      }
     },
     get: function (keys, callback) {
       if(errorState.isError) {


### PR DESCRIPTION
This PR should address this issue: https://github.com/guyellis/multi-level-cache/issues/41

Quite simply it sets a key AND the corresponding TTL when desired in the same request rather than in multiple. This prevents situations in which a key might get set without a TTL.

While I was in here, I failed a single test which caused many tests to fail. This is because at first error a test stops running, so cleanup never occurs. Moving cleanup to an `afterEach` should ensure cleanup always runs.

I should note that I also proved this functionality locally with a test script, and it worked as expected.