### PR TITLE
Fix sinon deprecation warnings

### DIFF
--- a/test/lib/cache-lib/test.node-cache.js
+++ b/test/lib/cache-lib/test.node-cache.js
@@ -6,7 +6,7 @@ var NodeCache = require('node-cache');
 
 describe('node-cache adapter', function(){
   it('should call callback if node-cache returns an error in keys', function(done){
-    var nodeCacheStub = sinon.stub(NodeCache.prototype, 'keys', function(callback){
+    var nodeCacheStub = sinon.stub(NodeCache.prototype, 'keys').callsFake(function(callback){
       return callback('fake error');
     });
 
@@ -20,7 +20,7 @@ describe('node-cache adapter', function(){
   });
 
   it('should call callback if node-cache returns an error in get', function(done){
-    var nodeCacheStub = sinon.stub(NodeCache.prototype, 'get', function(key, callback){
+    var nodeCacheStub = sinon.stub(NodeCache.prototype, 'get').callsFake(function(key, callback){
       return callback('fake error');
     });
 

--- a/test/lib/cache-lib/test.redis.js
+++ b/test/lib/cache-lib/test.redis.js
@@ -20,7 +20,7 @@ describe('redis adapter', function(){
 
   it('should call callback if redis returns an error in get', function(done) {
 
-    redisStub = sinon.stub(redis, 'createClient', function () {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function () {
       return {
         get: function (key, callback) {
           return callback('fake error');
@@ -41,7 +41,7 @@ describe('redis adapter', function(){
 
   it('should call callback if redis returns an error in set', function(done) {
 
-    redisStub = sinon.stub(redis, 'createClient', function () {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function () {
       return {
         set: function (key, value, callback) {
           return callback('fake error');
@@ -65,7 +65,7 @@ describe('redis adapter', function(){
       'set': sinon.stub().callsArg(2),
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function(){
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function(){
       return clientStub;
     });
 
@@ -81,7 +81,7 @@ describe('redis adapter', function(){
       'set': sinon.stub().callsArg(4),
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -99,7 +99,7 @@ describe('redis adapter', function(){
       'get': sinon.stub().callsArgWith(1, null, '{"a":"2015-04-21T04:58:20.648Z","b":"something"}'),
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -116,7 +116,7 @@ describe('redis adapter', function(){
       'get': sinon.stub().callsArgWith(1, null, null),
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -137,7 +137,7 @@ describe('redis adapter', function(){
       'del': sinon.stub().callsArg(1),
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -155,7 +155,7 @@ describe('redis adapter', function(){
       },
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -176,7 +176,7 @@ describe('redis adapter', function(){
       },
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -198,7 +198,7 @@ describe('redis adapter', function(){
       },
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -219,7 +219,7 @@ describe('redis adapter', function(){
         '{"a":"{foo:2015-04-21T04:58:20.648Z}","b":"something"}'),
       on: _.noop
     };
-    redisStub = sinon.stub(redis, 'createClient', function() {
+    redisStub = sinon.stub(redis, 'createClient').callsFake(function() {
       return clientStub;
     });
 
@@ -279,7 +279,7 @@ describe('redis adapter', function(){
       clientEventEmitter.get = function(key, callback) {
         return callback(null, JSON.stringify(testGetValue));
       };
-      redisStub = sinon.stub(redis, 'createClient', function () {
+      redisStub = sinon.stub(redis, 'createClient').callsFake(function () {
         return clientEventEmitter;
       });
       redisPlugin = redisAdapter({});
@@ -307,7 +307,7 @@ describe('redis adapter', function(){
     var redisPlugin;
     beforeEach(function(done){
       var clientEventEmitter = new EventEmitter();
-      redisStub = sinon.stub(redis, 'createClient', function () {
+      redisStub = sinon.stub(redis, 'createClient').callsFake(function () {
         return clientEventEmitter;
       });
       redisPlugin = redisAdapter({});

--- a/test/lib/test.multi.js
+++ b/test/lib/test.multi.js
@@ -32,10 +32,11 @@ function mockRedis() {
   if(!isIntegrationTest) {
     var connectionGoneStub, onErrorStub;
     before(function () {
-      connectionGoneStub = sinon.stub(redis.RedisClient.prototype, 'connection_gone', function () {
-        // do nothing
-      });
-      onErrorStub = sinon.stub(redis.RedisClient.prototype, 'on_error', function () {
+      connectionGoneStub = sinon.stub(redis.RedisClient.prototype, 'connection_gone')
+        .callsFake(function () {
+          // do nothing
+        });
+      onErrorStub = sinon.stub(redis.RedisClient.prototype, 'on_error').callsFake(function () {
         // do nothing
       });
     });
@@ -272,7 +273,7 @@ tests.forEach(function(test){
 
       it('should handle the local cache returning an error on get', function (done) {
         var multiCache = new MultiCache(localCacheName, remoteCacheName, testBothActive);
-        var localStub = sinon.stub(multiCache.localCache, 'get', function(keys, callback){
+        var localStub = sinon.stub(multiCache.localCache, 'get').callsFake(function(keys, callback){
           return callback('fake error', 'fake value');
         });
         multiCache.set(key, 'myValue', function (err, result) {
@@ -289,9 +290,10 @@ tests.forEach(function(test){
 
       it('should handle the remote cache returning an error on get', function (done) {
         var multiCache = new MultiCache(localCacheName, remoteCacheName, testBothActive);
-        var remoteStub = sinon.stub(multiCache.remoteCache, 'get', function(keys, callback){
-          return callback('fake error', 'fake value');
-        });
+        var remoteStub = sinon.stub(multiCache.remoteCache, 'get')
+          .callsFake(function(keys, callback){
+            return callback('fake error', 'fake value');
+          });
         multiCache.set(key, 'myValue', testRemoteOnly, function (err, result) {
           assert(!err);
           assert(!_.isEmpty(result));


### PR DESCRIPTION
While working on https://github.com/guyellis/multi-level-cache/pull/43 I was annoyed at the sinon warnings, so I fixed them.

You should find ~23 of these:

```
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
```

To no longer occur.